### PR TITLE
Add MoKA-HP to the RGBT tracking paper list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1228,6 +1228,10 @@ Xiao-Jun Wu, Zhenhua Feng, Josef Kittler.<br />
   [[paper](https://arxiv.org/abs/2511.17967)] 
   [[code](https://github.com/IdolLab/CADTrack)]
 
+- **MoKA-HP:** Zhixi Wu, Si Chen, Da-Han Wang, Shunzhi Zhu.<br />
+  "MoKA-HP: Motion-aware KAdaptation with historical prompts for efficient and robust RGB-T tracking." Neurocomputing (2026).
+  [[paper](https://www.sciencedirect.com/science/article/abs/pii/S0925231225028358)]
+
 - Jiahao Wang; Fang Liu; Hao Wang; Shuo Li; Xinyi Wang;Puhua Chen.<br />
   "Semantic Feature Purification for Adversarially-Aware RGB-T Tracking." AAAI (2026).
 


### PR DESCRIPTION
## Summary
- add the 2026 MoKA-HP paper to the `RGBT Tracking` section in `README.md`
- keep the update minimal and consistent with the existing awesome-list format

## Why
MoKA-HP is a recent RGBT tracking paper that is currently missing from the curated list.